### PR TITLE
Add missing install for package's node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,14 @@ install(
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
 )
+
+install(
+  PROGRAMS 
+    src/cpu_monitor.py
+    src/hdd_monitor.py
+    src/mem_monitor.py
+    src/net_monitor.py
+    src/ntp_monitor.py
+  DESTINATION 
+    ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
Fix missing install rule for the rospy node provide by the package (#2).

This way, it's not necessary sourcing devel before running the launch file.